### PR TITLE
Embed SQL template as inline method

### DIFF
--- a/base/src/main/scala/xerial/sbt/sql/SQL.scala
+++ b/base/src/main/scala/xerial/sbt/sql/SQL.scala
@@ -14,10 +14,8 @@ object SQL {
     val jdbcURL      = taskKey[String]("JDBC connection URL. e.g., jdbc:presto://api-presto.treasuredata.com:443/td-presto")
     val jdbcUser     = taskKey[String]("JDBC user name")
     val jdbcPassword = taskKey[String]("JDBC password")
-
-    val generateSQLModel = taskKey[Seq[(File, File)]]("create model classes from SQL files")
+    val generateSQLModel = taskKey[Seq[File]]("create model classes from SQL files")
     val sqlModelClasses  = taskKey[Seq[File]]("Generated SQL model classes")
-    val sqlResources     = taskKey[Seq[File]]("Generated SQL files")
   }
 
   object autoImport extends Keys
@@ -32,15 +30,12 @@ object SQL {
       val generator = new SQLModelClassGenerator(config, new SbtLogSupport(state.value.log)) //, state.value.log)
       generator.generate(
         GeneratorConfig(sqlDir.value,
-          (managedSourceDirectories in Compile).value.head,
-          (managedResourceDirectories in Compile).value.head
+          (managedSourceDirectories in Compile).value.head
         )
       )
     },
-    sqlModelClasses := generateSQLModel.value.map(_._1),
-    sqlResources := generateSQLModel.value.map(_._2),
+    sqlModelClasses := generateSQLModel.value,
     sourceGenerators in Compile += sqlModelClasses.taskValue,
-    resourceGenerators in Compile += sqlResources.taskValue,
     watchSources ++= (sqlDir.value ** "*.sql").get,
     jdbcUser := "",
     jdbcPassword := ""

--- a/base/src/main/scala/xerial/sbt/sql/SQLModelClassGenerator.scala
+++ b/base/src/main/scala/xerial/sbt/sql/SQLModelClassGenerator.scala
@@ -162,6 +162,7 @@ class SQLModelClassGenerator(jdbcConfig: JDBCConfig, log:LogSupport) {
          |import java.sql.ResultSet
          |
          |object ${name} {
+         |  def path : String = "/${packageName.replaceAll("\\.", "/")}/${name}.sql"
          |  def originalSql : String = ${embeddedSQL}
          |
          |  def apply(rs:ResultSet) : ${name} = {

--- a/base/src/main/scala/xerial/sbt/sql/SQLModelClassGenerator.scala
+++ b/base/src/main/scala/xerial/sbt/sql/SQLModelClassGenerator.scala
@@ -7,7 +7,7 @@ import sbt.{File, IO, _}
 
 case class Schema(columns: Seq[Column])
 case class Column(qname: String, reader:ColumnAccess, sqlType: java.sql.JDBCType, isNullable: Boolean, elementType: java.sql.JDBCType = JDBCType.NULL)
-case class GeneratorConfig(sqlDir:File, targetDir:File, resourceTargetDir:File)
+case class GeneratorConfig(sqlDir:File, targetDir:File)
 
 object SQLModelClassGenerator extends xerial.core.log.Logger {
 
@@ -72,9 +72,9 @@ class SQLModelClassGenerator(jdbcConfig: JDBCConfig, log:LogSupport) {
     }
   }
 
-  def generate(config:GeneratorConfig) : Seq[(File, File)] = {
+  def generate(config:GeneratorConfig) : Seq[File] = {
     // Submit queries using multi-threads to minimize the waiting time
-    val result = Seq.newBuilder[(File, File)]
+    val result = Seq.newBuilder[File]
     val buildTime = SQLModelClassGenerator.getBuildTime
     log.debug(s"SQLModelClassGenerator version:${SQLModelClassGenerator.getVersion}")
 
@@ -82,17 +82,15 @@ class SQLModelClassGenerator(jdbcConfig: JDBCConfig, log:LogSupport) {
 
     for (sqlFile <- (config.sqlDir ** "*.sql").get.par) {
       val path = sqlFile.relativeTo(config.sqlDir).get.getPath
-      val targetFile = config.resourceTargetDir / path
       val targetClassFile = config.targetDir / path.replaceAll("\\.sql$", ".scala")
 
       val sqlFilePath = sqlFile.relativeTo(baseDir).getOrElse(sqlFile)
       log.debug(s"Processing ${sqlFilePath}")
       val latestTimestamp = Math.max(sqlFile.lastModified(), buildTime)
-      if(targetFile.exists()
+      if(targetClassFile.exists()
         && targetClassFile.exists()
-        && latestTimestamp <= targetFile.lastModified()
         && latestTimestamp <= targetClassFile.lastModified()) {
-        log.debug(s"${targetFile.relativeTo(config.targetDir).getOrElse(targetFile)} is up-to-date")
+        log.debug(s"${targetClassFile.relativeTo(config.targetDir).getOrElse(targetClassFile)} is up-to-date")
       }
       else {
         val sql = IO.read(sqlFile)
@@ -102,17 +100,14 @@ class SQLModelClassGenerator(jdbcConfig: JDBCConfig, log:LogSupport) {
         val schema = checkResultSchema(limit0)
 
         // Write SQL template without type annotation
-        log.info(s"Generating SQL template: ${targetFile}")
-        IO.write(targetFile, template.noParam)
         val scalaCode = schemaToClass(sqlFile, config.sqlDir, schema, template)
         log.info(s"Generating model class: ${targetClassFile}")
         IO.write(targetClassFile, scalaCode)
-        targetFile.setLastModified(latestTimestamp)
         targetClassFile.setLastModified(latestTimestamp)
       }
 
       synchronized {
-        result += ((targetClassFile, targetFile))
+        result += targetClassFile
       }
     }
     result.result()
@@ -160,20 +155,21 @@ class SQLModelClassGenerator(jdbcConfig: JDBCConfig, log:LogSupport) {
     val paramNames = sqlTemplate.params.map(_.name)
     val sqlArgList = sqlTemplateArgs.mkString(", ")
 
+    val embeddedSQL = "\"\"\"" + sqlTemplate.noParam + "\"\"\""
+
     val code =
       s"""package ${packageName}
          |import java.sql.ResultSet
          |
          |object ${name} {
-         |  def path : String = "/${packageName.replaceAll("\\.", "/")}/${name}.sql"
-         |  def originalSql : String = {
-         |    scala.io.Source.fromInputStream(this.getClass.getResourceAsStream(path)).mkString
-         |  }
+         |  def originalSql : String = ${embeddedSQL}
+         |
          |  def apply(rs:ResultSet) : ${name} = {
          |    new ${name}(
          |      ${rsReader.mkString(",\n      ")}
          |    )
          |  }
+         |
          |  def sql(${sqlArgList}) : String = {
          |    var rendered = originalSql
          |    val params = Seq(${paramNames.map(x => "\"" + x + "\"").mkString(", ")})
@@ -222,7 +218,6 @@ class SQLModelClassGenerator(jdbcConfig: JDBCConfig, log:LogSupport) {
          |}
          |""".stripMargin
 
-    //info(code)
     code
   }
 

--- a/base/src/test/scala/xerial/sbt/sql/SQLModelClassGeneratorTest.scala
+++ b/base/src/test/scala/xerial/sbt/sql/SQLModelClassGeneratorTest.scala
@@ -21,8 +21,7 @@ class SQLModelClassGeneratorTest extends Spec {
       )
       g.generate(GeneratorConfig(
         new File("base/src/test/sql/presto"),
-        new File("target/sbt-0.13/src_managed/test"),
-        new File("target/sbt-0.13/resource_managed/test")
+        new File("target/sbt-0.13/src_managed/test")
       ))
     }
   }

--- a/td/src/sbt-test/sbt-sql-td/simple/test
+++ b/td/src/sbt-test/sbt-sql-td/simple/test
@@ -10,4 +10,4 @@
 
 # Confirm model file is generated
 > generateSQLModel
-$ exists target/scala-2.10/resource_managed/main/access_log.sql target/scala-2.10/src_managed/main/access_log.scala
+$ exists target/scala-2.10/src_managed/main/access_log.scala


### PR DESCRIPTION
@Lewuathe This PR is for embedding SQL templates as inline methods of the generated .scala files. 
This makes easy for us to find .sql files in IDE. Previously two SQL files (source and generated) were shown in file explorer.