### PR TITLE
Hint for optional output columns

### DIFF
--- a/base/src/main/scala/xerial/sbt/sql/SQLTemplate.scala
+++ b/base/src/main/scala/xerial/sbt/sql/SQLTemplate.scala
@@ -10,4 +10,4 @@ object SQLTemplate extends Logger {
   def apply(sql: String): SQLTemplate = SQLTemplateCompiler.compile(sql)
 }
 
-case class SQLTemplate(sql: String, populated: String, params: Seq[Preamble.FunctionArg], imports: Seq[Preamble.Import])
+case class SQLTemplate(sql: String, populated: String, params: Seq[Preamble.FunctionArg], imports: Seq[Preamble.Import], optionals: Seq[Preamble.Optional])

--- a/base/src/main/scala/xerial/sbt/sql/SQLTemplateCompiler.scala
+++ b/base/src/main/scala/xerial/sbt/sql/SQLTemplateCompiler.scala
@@ -135,7 +135,8 @@ object SQLTemplateCompiler
       sql = parsed.sql,
       populated = populatedSQL,
       params = params,
-      imports = parsed.imports
+      imports = parsed.imports,
+      optionals = parsed.optionals
     )
   }
 }

--- a/base/src/main/scala/xerial/sbt/sql/SQLTemplateParser.scala
+++ b/base/src/main/scala/xerial/sbt/sql/SQLTemplateParser.scala
@@ -34,6 +34,7 @@ object Preamble
     }
   }
   case class Import(target:String) extends Preamble
+  case class Optional(columns:List[String]) extends Preamble
 }
 
 import Preamble._
@@ -50,7 +51,7 @@ object SQLTemplateParser
   case class ParseError(message: String, pos: Option[Pos])
           extends Exception(message)
 
-  case class ParseResult(sql: String, args: Seq[FunctionArg], imports: Seq[Import])
+  case class ParseResult(sql: String, args: Seq[FunctionArg], imports: Seq[Import], optionals: Seq[Optional])
 
   def parse(template: String): ParseResult =
   {
@@ -73,6 +74,7 @@ object SQLTemplateParser
     val sql = remaining.result().mkString("\n")
     val p = preamble.result()
     val imports = p.collect{case i:Import => i}
+    val optionals = p.collect{case o:Optional => o}
     val f = {
       val defs = p.collect {case f: Function => f}
       if (defs.size > 1) {
@@ -93,7 +95,7 @@ object SQLTemplateParser
     // Allow SQL template without any function header for backward compatibility
     // Escape backslash
     val sanitized = removeParamType(sql).replaceAll("\\\\","\\\\\\\\")
-    ParseResult(sanitized, f.map(_.args).getOrElse(parametersInsideSQLBody), imports)
+    ParseResult(sanitized, f.map(_.args).getOrElse(parametersInsideSQLBody), imports, optionals)
   }
 
   def parseFunction(f:String) : Function = {
@@ -121,10 +123,11 @@ object SQLTemplateParser
 
     def function: Parser[Function] = "@(" ~ args ~ ")" ^^ { case _ ~ args ~ _ => Function(args) }
     def importStmt: Parser[Import] = "@import" ~ classRef ^^ { case _ ~ i => Import(i.toString) }
+    def optional: Parser[Optional] = "@optional(" ~ repsep(ident, ',') ~ ")" ^^ { case _ ~ cols ~ _=> Optional(cols) }
     def classRef: Parser[String] = ident ~ rep('.' ~ ident) ^^ {
       case h ~ t => (h :: t.map(_._2)).mkString(".")
     }
-    def preamble : Parser[Preamble] = function | importStmt
+    def preamble : Parser[Preamble] = function | importStmt | optional
   }
 
   val embeddedParamPattern = """\$\{\s*(\w+)\s*(:\s*(\w+))?\s*(=\s*([^\}]+)\s*)?\}""".r

--- a/base/src/test/sql/presto/sample/optional_by_column_name.sql
+++ b/base/src/test/sql/presto/sample/optional_by_column_name.sql
@@ -1,0 +1,4 @@
+select 
+  1      as num,
+  'hoge' as str__optional,
+  true   as bool__optional

--- a/base/src/test/sql/presto/sample/optional_by_preamble.sql
+++ b/base/src/test/sql/presto/sample/optional_by_preamble.sql
@@ -1,0 +1,5 @@
+@optional(str, bool)
+select 
+  1      as num,
+  'hoge' as str,
+  true   as bool


### PR DESCRIPTION
Support hinting to generate optional output columns as `Option[T]`. This pull request contains two ways below. Which one is preferable? 🤔 

## by column name

```sql
select 
  1      as num,
  'hoge' as str__optional,
  true   as bool__optional
```

## by template preamble

```sql
@optional(str, bool)
select 
  1      as num,
  'hoge' as str,
  true   as bool
```