### PR TITLE
Migrate to sbt's built-in Sonatype publish method

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,6 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 
 val buildSettings = Seq(
   organization        := "org.xerial.sbt",
-  sonatypeProfileName := "org.xerial",
   licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
   homepage := Some(url("https://github.com/xerial/sbt-sql")),
   scmInfo := Some(
@@ -20,13 +19,26 @@ val buildSettings = Seq(
   developers := List(
     Developer(id = "leo", name = "Taro L. Saito", email = "leo@xerial.org", url = url("http://xerial.org/leo"))
   ),
-  publishTo              := sonatypePublishToBundle.value,
+  publishTo := {
+    val centralPortal = "https://central.sonatype.com/api/v1/publisher"
+    if (isSnapshot.value) {
+      Some("snapshots".at(s"$centralPortal/uploads/bundle"))
+    } else {
+      Some("releases".at(centralPortal))
+    }
+  },
   organizationName       := "Xerial project",
   organizationHomepage   := Some(new URL("https://xerial.org/")),
   description            := "A sbt plugin for generating model classes from SQL files",
   publishMavenStyle      := true,
   Test / publishArtifact := false,
   pomIncludeRepository   := { _ => false },
+  credentials ++= {
+    for {
+      username <- sys.env.get("SONATYPE_USERNAME")
+      password <- sys.env.get("SONATYPE_PASSWORD")
+    } yield Credentials("Sonatype Nexus Repository Manager", "central.sonatype.com", username, password)
+  }.toSeq,
   parallelExecution      := true,
   scalacOptions ++= Seq("-encoding", "UTF-8", "-deprecation", "-unchecked"),
   libraryDependencies ++= Seq(

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,6 +1,5 @@
 // Ignore binary incompatible errors for libraries using scala-xml.
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always"
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
 addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.3.1")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt" % "2.5.5")
 addSbtPlugin("com.github.sbt" % "sbt-dynver"   % "5.1.1")


### PR DESCRIPTION
## Summary
- Migrate from sbt-sonatype plugin to sbt's native Sonatype publishing support
- Remove external plugin dependency for more maintainable release process

## Changes
- Removed `sbt-sonatype` plugin from `project/plugin.sbt`
- Removed `sonatypeProfileName` setting (no longer needed)
- Updated `publishTo` to use Sonatype Central Portal URLs directly
- Added credentials configuration using `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` environment variables

## Motivation
This reduces external plugin dependencies and uses the standard sbt publishing as documented in sbt's official documentation, making it more maintainable and compatible with Sonatype's new Central Portal infrastructure.

## Test plan
- [x] Build compiles successfully
- [ ] Publishing workflow should work with proper credentials

Similar to https://github.com/xerial/sbt-pack/pull/581

🤖 Generated with [Claude Code](https://claude.ai/code)